### PR TITLE
Team Topologies Glossary Translation to Portuguese

### DIFF
--- a/Team-Topologies-Glossary-in-Portuguese.md
+++ b/Team-Topologies-Glossary-in-Portuguese.md
@@ -2,12 +2,12 @@
 | --------------- | --------------- | ------------- |
 | API (application programming interface) | ||
 | application monolith | ||
-| bounded context | ||
-| Brooks’s law | ||
-| cognitive load | ||
-| collaboration mode | ||
-| complicated-subsystem team | ||
-| Conway’s law | ||
+| bounded context | Contexto Delimitado ||
+| Brooks’s law | Lei de Brook ||
+| cognitive load | Carga Cognitiva ||
+| collaboration mode | Modo de Colaboração ||
+| complicated-subsystem team | Time de Subsistemas Complicados ||
+| Conway’s law | Lei de Conway ||
 | domain complexity | ||
 | Dunbar’s number | ||
 | enabling team | ||

--- a/Team-Topologies-Glossary-in-Portuguese.md
+++ b/Team-Topologies-Glossary-in-Portuguese.md
@@ -1,33 +1,33 @@
 | Term in English | Term in Portuguese | Usage Example |
 | --------------- | --------------- | ------------- |
-| API (application programming interface) | API (interface de programação de aplicações) | Novas funções podem ser incorporadas em outras ferramentas de software usando uma interface de programação de aplicações (API). |
-| application monolith | aplicação monólito | Monólito significa “obra construída em uma só pedra” por isso é utilizado para definir a arquitetura de alguns sistemas construídos de forma única e não dividida que são chamadas de aplicação monólito. |
-| bounded context | contexto delimitado | Sinaliza até aonde vai a responsabilidade de cada parte do sistema. Cada contexto possui suas responsabilidades claramente definidas. |
-| Brooks’s law | lei de Brooks | Resumidamente a lei de Brooks afirma que adicionar pessoas a um projeto atrasado, na verdade atrasa ainda mais o projeto. |
-| cognitive load | carga cognitiva | Carga cognitiva se refere ao nível de utilização de recursos psicológicos como memória, atenção, percepção, representação de conhecimento, raciocínio e criatividade na resolução de problemas. |
-| collaboration mode | modo colaborativo | No modo colaborativo os times trabalham juntos, por um período de tempo definido, para descobrir coisas novas como APIs, práticas, tecnologias e outros. |
+| API (application programming interface) | API (interface de programação de aplicações) | uma descrição e especificação de como interagir programaticamente com software.|
+| application monolith | aplicação monólito | Uma única e grande aplicação, com muitas dependências e responsabilidades que possivelmente expõe muitos serviços e/ou diferentes jornadas de usuário. |
+| bounded context | contexto delimitado | uma unidade de particionamento de um modelo de domínio (ou sistema) grande em partes menores, cada qual representando internamente uma área de domínio de negócios consistente. |
+| Brooks’s law | lei de Brooks | lei cunhada por Mel Conway que afirma que o design do sistema copiará as estruturas de comunicação da organização que o projeta. |
+| cognitive load | carga cognitiva | a quantidade da memória de trabalho sendo utilizada. |
+| collaboration mode | modo colaborativo | responsável por construir e manter uma parte do sistema que depende profundamente em conhecimento de especialistas. |
 | complicated-subsystem team | time de subsistemas complicados | Um time de subsistemas complicados é responsável por construir e manter uma parte do sistema que depende de habilidades e conhecimentos específicos. |
-| Conway’s law | lei de Conway | A lei de Conway indica que as estruturas dos sistemas de software são "espelhos" das estruturas das organizações que os desenvolvem. |
-| domain complexity | complexidade do domínio | No contexto do DDD (domain-driven design), a complexidade do domínio refere-se à complexidade do domínio de negócios que está sendo modelado. |
-| Dunbar’s number | número de Dunbar | O número de Dunbar é um conceito da psicologia que se refere ao número máximo de relações sociais que um indivíduo pode manter a qualquer momento. |
-| enabling team | time habilitador | Um time habilitador é normalmente um time de especialistas em uma área específica que colaborarão com equipes alinhadas ao fluxo (stream-aligned) para ajudá-las a obter competências que lhes faltam. |
-| extraneous cognitive load | carga cognitiva estranha | A carga cognitiva estranha é uma carga cognitiva que não está relacionada à dificuldade inerente à tarefa em questão, mas sim à forma como a informação é apresentada ou ao contexto em que é aprendida. |
-| facilitating mode | modo de facilitação | No modo de facilitação, um time habilitador apoia e complementa outra equipe para enfrentar desafios e acelerar essa equipe, por exemplo. |
-| flow of change | fluxo de mudança | Projetos organizacionais tradicionais têm silos funcionais que impedem um fluxo de mudança rápido. |
-| fracture plane | plano de fratura | Um plano de fratura é uma emenda natural no sistema de software que permite que o sistema seja dividido facilmente em duas ou mais partes. |
-| germane cognitive load | carga cognitiva pertinente | A carga cognitiva pertinente refere-se à quantidade de esforço mental que é necessário para processar e entender novas informações de uma forma significativa. |
-| intrinsic cognitive load | carga cognitiva intrínseca | A carga cognitiva intrínseca é a carga resultante da complexidade inerente à tarefa de aprendizagem. |
-| joined-at-the-database monolith | monólito acoplado pela base de dados | Um monólito acoplado pela base de dados possui várias aplicações ou serviços conectados à uma base de dados única e compartilhada. |
-| monolithic build | construção monolítica | Numa construção monolítica todos os componentes das aplicações e serviços são construídos juntos como uma única unidade. |
-| monolithic model | modelo monolítico | Um modelo monolítico é um modelo de design de software no qual todos os componentes de um sistema são fortemente acoplados e integrados em um todo unificado. |
-| monolithic release | lançamento monolítico | Um lançamento monolítico é um tipo de release de software onde todos os componentes de um sistema são lançados juntos numa única release. |
-| monolithic thinking | pensamento monolítico | O pensamento monolítico refere-se a uma mentalidade ou abordagem que vê uma questão ou problema complexo como uma entidade única e unificada e não como uma coleção de partes menores e interconectadas. |
-| monolithic workplace | local de trabalho monolítico | Um local de trabalho monolítico é um tipo de estrutura organizacional na qual se espera que todos os funcionários estejam em conformidade com um único conjunto de valores, crenças e práticas. |
-| organizational sensing | percepção organizacional | A percepção organizacional compreende os processos pelos quais indivíduos ou organizações interpretam e organizam suas percepções e buscam dar sentido ao ambiente. |
-| platform team | time de plataforma |  O time de plataforma tem como propósito permitir os times alinhados ao fluxo (stream-aligned) entregar seu trabalho com completa autonomia, fornecendo, por exemplo, serviços para reduzir a carga cognitiva dos times alinhados ao fluxo. |
-| reverse Conway maneuver | manobra reversa de Conway | Ao realizarmos a manobra reversa de Conway fazemos um exercício consciente de escolha de um design organizacional que irá inevitavelmente produzir um produto/serviço com o design que queremos. |
-| stream-aligned team | time alinhado ao fluxo | Os times alinhado ao fluxo são compostos por uma mistura de pessoas com habilidades cross-funcionais, formando o que chamamos de times multi funcionais alinhados à algum fluxo de negócio. |
-| team API | API do time | A API do time serve para dar clareza e visibilidade acerca das aplicações e serviços que este time presta de forma a diminuir a interdependência entre os times. |
-| Team Topologies | Topologia de Times | Topologia de Times é um livro escrito por Matthew Skelton e Manuel Pais focado na problemática de como construir times de alta confiança. |
-| thinnest viable platform | menor plataforma viável | A menor plataforma viável deve ser a mais simples possível e oferecida como um auto-serviço. Um exemplo seria uma página wiki detalhando algum serviço usado como uma plataforma. |
-| X-as-a-Service mode | modo X-como-um-Serviço | No modo de interação X-como-um-serviço um time provê e outro time consome algo "como um serviço".  |
+| Conway’s law | lei de Conway | a lei de Conway indica que as estruturas dos sistemas de software são "espelhos" das estruturas das organizações que os desenvolvem. |
+| domain complexity | complexidade do domínio | o quão complexo é o problema que está sendo solucionado pelo software. |
+| Dunbar’s number | número de Dunbar | cunhado pelo antropólogo Robin Dunbar que afirma que quinze é o limite de pessoas que uma pessoa pode confiar; desses, apenas cerca de cinco podem ser intimamente conhecidas e confiáveis. |
+| enabling team | time habilitador | time(s) composto(s) de especialistas em um determinado domínio técnico ou produto; eles ajudam a preencher as lacunas de capacitação. |
+| extraneous cognitive load | carga cognitiva estranha | Relacionadas ao ambiente onde a tarefa está sendo executada (Ex. “Como eu faço a implantação desse componente novamente?”, “Como é a configuração desse serviço?”). |
+| facilitating mode | modo de facilitação | time(s) auxiliando (ou sendo auxiliado por) outro time na retirada de impedimentos. |
+| flow of change | fluxo de mudança | um fluxo de atualizações ou alterações relacionadas a um serviço de software ou sistema, geralmente alinhados aos objetivos do usuário ou outro foco central do negócio.  |
+| fracture plane | plano de fratura | uma "emenda" natural no sistema de software que permite que o sistema seja dividido facilmente em duas ou mais partes. |
+| germane cognitive load | carga cognitiva pertinente | relacionado aos aspectos da tarefa que precisam de atenção especial para a aprendizagem ou o alto desempenho (Ex. “Como esse serviço deveria interagir com o serviço ABC?”). |
+| intrinsic cognitive load | carga cognitiva intrínseca | relacionado aos aspectos fundamentais da tarefa no espaço do problema (Ex. “Qual é a estrutura de uma classe Java?” “Como eu crio um novo método?”). |
+| joined-at-the-database monolith | monólito acoplado pela base de dados | composto de várias aplicações ou serviços, todos acoplados a um mesmo esquema de banco de dados, tornando difícil realizar separadamente alterações, testes e implantações. |
+| monolithic build | construção monolítica | precisa realizar uma construção gigante na esteira de integração contínua (CI) de modo a implantar uma nova versão de um componente. |
+| monolithic model | modelo monolítico | software que tenta forçar uma única linguagem de domínio e representação (formato) através de diversos contextos diferentes. |
+| monolithic release | lançamento monolítico | um conjunto de componentes menores empacotados juntos numa entrega. |
+| monolithic thinking | pensamento monolítico | pensamento de time "tamanho-único" que leva a restrições desnecessárias nas tecnologias e nas abordagens de implementação entre os times. |
+| monolithic workplace | local de trabalho monolítico | um único padrão de leiaute de escritório para todos os times e indivíduos no mesmo local geográfico. |
+| organizational sensing | percepção organizacional | times e suas comunicações internas e externas são os "sentidos" da organização (visão, audição, tato, olfato e paladar). |
+| platform team | time de plataforma | auxiliam os times alinhados ao fluxo (stream-aligned) a entregar seu trabalho com autonomia substancial. |
+| reverse Conway maneuver | manobra reversa de Conway | organizações devem evoluir suas estruturas organizacionais e de time para alcançar a arquitetura desejada. |
+| stream-aligned team | time alinhado ao fluxo | um time alinhado à um único fluxo de valor de trabalho |
+| team API | API do time | Uma API em torno de cada time. |
+| Team Topologies | Topologia de Times | um modelo para desenho organizacional que fornece um mecanismo chave, tecnologicamente agnóstico, para empresas modernas que desenvolvem software intensivamente e que auxilia a perceberem quando uma mudança na estratégia é necessária (seja do ponto de vista de negócios ou de tecnologia).  |
+| thinnest viable platform | menor plataforma viável | um balanço cuidados para manter a plataforma pequena e ao mesmo tempo, garantir que essa plataforma esteja auxiliando a acelerar e simplificar o processo de entrega de software dos times que utilizam essa plataforma. |
+| X-as-a-Service mode | modo X-como-um-Serviço | consumir ou fornecer algo com a mínima colaboração possível. |

--- a/Team-Topologies-Glossary-in-Portuguese.md
+++ b/Team-Topologies-Glossary-in-Portuguese.md
@@ -1,33 +1,33 @@
 | Term in English | Term in Portuguese | Usage Example |
 | --------------- | --------------- | ------------- |
 | API (application programming interface) | API (interface de programação de aplicações) | uma descrição e especificação de como interagir programaticamente com software.|
-| application monolith | aplicação monólito | Uma única e grande aplicação, com muitas dependências e responsabilidades que possivelmente expõe muitos serviços e/ou diferentes jornadas de usuário. |
+| application monolith | aplicação monólito | uma única e grande aplicação com muitas dependências e responsabilidades e que possivelmente expõe muitos serviços e/ou diferentes jornadas de usuário. |
 | bounded context | contexto delimitado | uma unidade de particionamento de um modelo de domínio (ou sistema) grande em partes menores, cada qual representando internamente uma área de domínio de negócios consistente. |
-| Brooks’s law | lei de Brooks | lei cunhada por Mel Conway que afirma que o design do sistema copiará as estruturas de comunicação da organização que o projeta. |
+| Brooks’s law | lei de Brooks | lei cunhada por Fred Brooks que afirma que acrescentar novas pessoas a um time não aumenta imediatamente a capacidade deste time. |
 | cognitive load | carga cognitiva | a quantidade da memória de trabalho sendo utilizada. |
-| collaboration mode | modo colaborativo | responsável por construir e manter uma parte do sistema que depende profundamente em conhecimento de especialistas. |
+| collaboration mode | modo colaborativo | time(s) trabalhando estreitamente junto com um outro time. |
 | complicated-subsystem team | time de subsistemas complicados | Um time de subsistemas complicados é responsável por construir e manter uma parte do sistema que depende de habilidades e conhecimentos específicos. |
-| Conway’s law | lei de Conway | a lei de Conway indica que as estruturas dos sistemas de software são "espelhos" das estruturas das organizações que os desenvolvem. |
+| Conway’s law | lei de Conway | lei cunhada por Mel Conway que afirma que o design do sistema copiará as estruturas de comunicação da organização que o projeta. |
 | domain complexity | complexidade do domínio | o quão complexo é o problema que está sendo solucionado pelo software. |
-| Dunbar’s number | número de Dunbar | cunhado pelo antropólogo Robin Dunbar que afirma que quinze é o limite de pessoas que uma pessoa pode confiar; desses, apenas cerca de cinco podem ser intimamente conhecidas e confiáveis. |
+| Dunbar’s number | número de Dunbar | cunhado pelo antropólogo Robin Dunbar que afirma que quinze é o limite de pessoas que uma pessoa pode confiar; dessas, apenas cerca de cinco podem ser intimamente conhecidas e confiáveis. |
 | enabling team | time habilitador | time(s) composto(s) de especialistas em um determinado domínio técnico ou produto; eles ajudam a preencher as lacunas de capacitação. |
-| extraneous cognitive load | carga cognitiva estranha | Relacionadas ao ambiente onde a tarefa está sendo executada (Ex. “Como eu faço a implantação desse componente novamente?”, “Como é a configuração desse serviço?”). |
+| extraneous cognitive load | carga cognitiva estranha | relacionadas ao ambiente onde a tarefa está sendo executada (Ex. “Como eu faço a implantação desse componente novamente?”, “Como é a configuração desse serviço?”). |
 | facilitating mode | modo de facilitação | time(s) auxiliando (ou sendo auxiliado por) outro time na retirada de impedimentos. |
 | flow of change | fluxo de mudança | um fluxo de atualizações ou alterações relacionadas a um serviço de software ou sistema, geralmente alinhados aos objetivos do usuário ou outro foco central do negócio.  |
 | fracture plane | plano de fratura | uma "emenda" natural no sistema de software que permite que o sistema seja dividido facilmente em duas ou mais partes. |
 | germane cognitive load | carga cognitiva pertinente | relacionado aos aspectos da tarefa que precisam de atenção especial para a aprendizagem ou o alto desempenho (Ex. “Como esse serviço deveria interagir com o serviço ABC?”). |
-| intrinsic cognitive load | carga cognitiva intrínseca | relacionado aos aspectos fundamentais da tarefa no espaço do problema (Ex. “Qual é a estrutura de uma classe Java?” “Como eu crio um novo método?”). |
+| intrinsic cognitive load | carga cognitiva intrínseca | relacionado aos aspectos fundamentais da tarefa no espaço do problema (Ex. “Qual é a estrutura de uma classe Java?”, “Como eu crio um novo método?”). |
 | joined-at-the-database monolith | monólito acoplado pela base de dados | composto de várias aplicações ou serviços, todos acoplados a um mesmo esquema de banco de dados, tornando difícil realizar separadamente alterações, testes e implantações. |
-| monolithic build | construção monolítica | precisa realizar uma construção gigante na esteira de integração contínua (CI) de modo a implantar uma nova versão de um componente. |
+| monolithic build | construção monolítica | necessita de um build gigante na esteira de integração contínua (CI) para implantar uma nova versão de um componente. |
 | monolithic model | modelo monolítico | software que tenta forçar uma única linguagem de domínio e representação (formato) através de diversos contextos diferentes. |
 | monolithic release | lançamento monolítico | um conjunto de componentes menores empacotados juntos numa entrega. |
 | monolithic thinking | pensamento monolítico | pensamento de time "tamanho-único" que leva a restrições desnecessárias nas tecnologias e nas abordagens de implementação entre os times. |
 | monolithic workplace | local de trabalho monolítico | um único padrão de leiaute de escritório para todos os times e indivíduos no mesmo local geográfico. |
 | organizational sensing | percepção organizacional | times e suas comunicações internas e externas são os "sentidos" da organização (visão, audição, tato, olfato e paladar). |
-| platform team | time de plataforma | auxiliam os times alinhados ao fluxo (stream-aligned) a entregar seu trabalho com autonomia substancial. |
+| platform team | time de plataforma | auxiliam os times alinhados ao fluxo (stream-aligned) a entregar seu trabalho com grande autonomia. |
 | reverse Conway maneuver | manobra reversa de Conway | organizações devem evoluir suas estruturas organizacionais e de time para alcançar a arquitetura desejada. |
 | stream-aligned team | time alinhado ao fluxo | um time alinhado à um único fluxo de valor de trabalho |
 | team API | API do time | Uma API em torno de cada time. |
-| Team Topologies | Topologia de Times | um modelo para desenho organizacional que fornece um mecanismo chave, tecnologicamente agnóstico, para empresas modernas que desenvolvem software intensivamente e que auxilia a perceberem quando uma mudança na estratégia é necessária (seja do ponto de vista de negócios ou de tecnologia).  |
-| thinnest viable platform | menor plataforma viável | um balanço cuidados para manter a plataforma pequena e ao mesmo tempo, garantir que essa plataforma esteja auxiliando a acelerar e simplificar o processo de entrega de software dos times que utilizam essa plataforma. |
+| Team Topologies | Topologia de Times | um modelo para desenho organizacional que fornece um mecanismo chave, tecnologicamente agnóstico, para empresas modernas que desenvolvem software intensivamente e que auxilia a perceber quando uma mudança na estratégia é necessária (seja do ponto de vista de negócios ou de tecnologia).  |
+| thinnest viable platform | menor plataforma viável | um balanço cuidadoso para manter a plataforma pequena e ao mesmo tempo, garantir que essa plataforma esteja auxiliando a acelerar e simplificar o processo de entrega de software dos times que utilizam essa plataforma. |
 | X-as-a-Service mode | modo X-como-um-Serviço | consumir ou fornecer algo com a mínima colaboração possível. |

--- a/Team-Topologies-Glossary-in-Portuguese.md
+++ b/Team-Topologies-Glossary-in-Portuguese.md
@@ -1,33 +1,33 @@
 | Term in English | Term in Portuguese | Usage Example |
 | --------------- | --------------- | ------------- |
-| API (application programming interface) | ||
-| application monolith | ||
-| bounded context | Contexto Delimitado ||
-| Brooks’s law | Lei de Brook ||
-| cognitive load | Carga Cognitiva ||
-| collaboration mode | Modo de Colaboração ||
-| complicated-subsystem team | Time de Subsistemas Complicados ||
-| Conway’s law | Lei de Conway ||
-| domain complexity | ||
-| Dunbar’s number | ||
-| enabling team | ||
-| extraneous cognitive load | ||
-| facilitating mode | ||
-| flow of change | ||
-| fracture plane | ||
-| germane cognitive load | ||
-| intrinsic cognitive load | ||
-| joined-at-the-database monolith | ||
-| monolithic build | ||
-| monolithic model | ||
-| monolithic release | ||
-| monolithic thinking | ||
-| monolithic workplace | ||
-| organizational sensing | ||
-| platform team | ||
-| reverse Conway maneuver | ||
-| stream-aligned team | ||
-| team API | ||
-| Team Topologies | ||
-| thinnest viable platform | ||
-| X-as-a-Service mode | ||
+| API (application programming interface) | API (interface de programação de aplicações) | Novas funções podem ser incorporadas em outras ferramentas de software usando uma interface de programação de aplicações (API). |
+| application monolith | aplicação monólito | Monólito significa “obra construída em uma só pedra” por isso é utilizado para definir a arquitetura de alguns sistemas construídos de forma única e não dividida que são chamadas de aplicação monólito. |
+| bounded context | contexto delimitado | Sinaliza até aonde vai a responsabilidade de cada parte do sistema. Cada contexto possui suas responsabilidades claramente definidas. |
+| Brooks’s law | lei de Brooks | Resumidamente a lei de Brooks afirma que adicionar pessoas a um projeto atrasado, na verdade atrasa ainda mais o projeto. |
+| cognitive load | carga cognitiva | Carga cognitiva se refere ao nível de utilização de recursos psicológicos como memória, atenção, percepção, representação de conhecimento, raciocínio e criatividade na resolução de problemas. |
+| collaboration mode | modo colaborativo | No modo colaborativo os times trabalham juntos, por um período de tempo definido, para descobrir coisas novas como APIs, práticas, tecnologias e outros. |
+| complicated-subsystem team | time de subsistemas complicados | Um time de subsistemas complicados é responsável por construir e manter uma parte do sistema que depende de habilidades e conhecimentos específicos. |
+| Conway’s law | lei de Conway | A lei de Conway indica que as estruturas dos sistemas de software são "espelhos" das estruturas das organizações que os desenvolvem. |
+| domain complexity | complexidade do domínio | No contexto do DDD (domain-driven design), a complexidade do domínio refere-se à complexidade do domínio de negócios que está sendo modelado. |
+| Dunbar’s number | número de Dunbar | O número de Dunbar é um conceito da psicologia que se refere ao número máximo de relações sociais que um indivíduo pode manter a qualquer momento. |
+| enabling team | time habilitador | Um time habilitador é normalmente um time de especialistas em uma área específica que colaborarão com equipes alinhadas ao fluxo (stream-aligned) para ajudá-las a obter competências que lhes faltam. |
+| extraneous cognitive load | carga cognitiva estranha | A carga cognitiva estranha é uma carga cognitiva que não está relacionada à dificuldade inerente à tarefa em questão, mas sim à forma como a informação é apresentada ou ao contexto em que é aprendida. |
+| facilitating mode | modo de facilitação | No modo de facilitação, um time habilitador apoia e complementa outra equipe para enfrentar desafios e acelerar essa equipe, por exemplo. |
+| flow of change | fluxo de mudança | Projetos organizacionais tradicionais têm silos funcionais que impedem um fluxo de mudança rápido. |
+| fracture plane | plano de fratura | Um plano de fratura é uma emenda natural no sistema de software que permite que o sistema seja dividido facilmente em duas ou mais partes. |
+| germane cognitive load | carga cognitiva pertinente | A carga cognitiva pertinente refere-se à quantidade de esforço mental que é necessário para processar e entender novas informações de uma forma significativa. |
+| intrinsic cognitive load | carga cognitiva intrínseca | A carga cognitiva intrínseca é a carga resultante da complexidade inerente à tarefa de aprendizagem. |
+| joined-at-the-database monolith | monólito acoplado pela base de dados | Um monólito acoplado pela base de dados possui várias aplicações ou serviços conectados à uma base de dados única e compartilhada. |
+| monolithic build | construção monolítica | Numa construção monolítica todos os componentes das aplicações e serviços são construídos juntos como uma única unidade. |
+| monolithic model | modelo monolítico | Um modelo monolítico é um modelo de design de software no qual todos os componentes de um sistema são fortemente acoplados e integrados em um todo unificado. |
+| monolithic release | lançamento monolítico | Um lançamento monolítico é um tipo de release de software onde todos os componentes de um sistema são lançados juntos numa única release. |
+| monolithic thinking | pensamento monolítico | O pensamento monolítico refere-se a uma mentalidade ou abordagem que vê uma questão ou problema complexo como uma entidade única e unificada e não como uma coleção de partes menores e interconectadas. |
+| monolithic workplace | local de trabalho monolítico | Um local de trabalho monolítico é um tipo de estrutura organizacional na qual se espera que todos os funcionários estejam em conformidade com um único conjunto de valores, crenças e práticas. |
+| organizational sensing | percepção organizacional | A percepção organizacional compreende os processos pelos quais indivíduos ou organizações interpretam e organizam suas percepções e buscam dar sentido ao ambiente. |
+| platform team | time de plataforma |  O time de plataforma tem como propósito permitir os times alinhados ao fluxo (stream-aligned) entregar seu trabalho com completa autonomia, fornecendo, por exemplo, serviços para reduzir a carga cognitiva dos times alinhados ao fluxo. |
+| reverse Conway maneuver | manobra reversa de Conway | Ao realizarmos a manobra reversa de Conway fazemos um exercício consciente de escolha de um design organizacional que irá inevitavelmente produzir um produto/serviço com o design que queremos. |
+| stream-aligned team | time alinhado ao fluxo | Os times alinhado ao fluxo são compostos por uma mistura de pessoas com habilidades cross-funcionais, formando o que chamamos de times multi funcionais alinhados à algum fluxo de negócio. |
+| team API | API do time | A API do time serve para dar clareza e visibilidade acerca das aplicações e serviços que este time presta de forma a diminuir a interdependência entre os times. |
+| Team Topologies | Topologia de Times | Topologia de Times é um livro escrito por Matthew Skelton e Manuel Pais focado na problemática de como construir times de alta confiança. |
+| thinnest viable platform | menor plataforma viável | A menor plataforma viável deve ser a mais simples possível e oferecida como um auto-serviço. Um exemplo seria uma página wiki detalhando algum serviço usado como uma plataforma. |
+| X-as-a-Service mode | modo X-como-um-Serviço | No modo de interação X-como-um-serviço um time provê e outro time consome algo "como um serviço".  |


### PR DESCRIPTION
Translation to portuguese of the Glossary from the Team Topologies book.